### PR TITLE
Added initial FHIR API support and updated to .NET Core 3.1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/bin/Debug/netcoreapp3.0/Cdc.Vocabulary.WebApi.dll",
+            "program": "${workspaceFolder}/src/bin/Debug/netcoreapp3.1/Cdc.Vocabulary.WebApi.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src",
             "stopAtEntry": false,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine as build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine as build
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT true
 
@@ -9,7 +9,7 @@ WORKDIR /src
 RUN dotnet publish -c Release
 
 # Run stage
-FROM mcr.microsoft.com/dotnet/core-nightly/aspnet:3.0-alpine as run
+FROM mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1-alpine as run
 
 RUN apk update && apk upgrade --no-cache
 
@@ -20,7 +20,7 @@ ENV VOCABULARY_PORT ${VOCABULARY_PORT}
 EXPOSE ${VOCABULARY_PORT}/tcp
 ENV ASPNETCORE_URLS http://*:${VOCABULARY_PORT}
 
-COPY --from=build /src/bin/Release/netcoreapp3.0/publish /app
+COPY --from=build /src/bin/Release/netcoreapp3.1/publish /app
 WORKDIR /app
 
 # don't run as root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /src
 RUN dotnet publish -c Release
 
 # Run stage
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0-alpine as run
+FROM mcr.microsoft.com/dotnet/core-nightly/aspnet:3.0-alpine as run
 
 RUN apk update && apk upgrade --no-cache
 
@@ -29,4 +29,3 @@ RUN chmod g+rwx /app/Cdc.Vocabulary.WebApi.dll
 USER 1001
 
 ENTRYPOINT [ "dotnet", "Cdc.Vocabulary.WebApi.dll" ]
-

--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/bin/Debug/netcoreapp3.0/Cdc.Vocabulary.WebApi.dll",
+      "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/Cdc.Vocabulary.WebApi.dll",
       "args": [],
       "cwd": "${workspaceFolder}",
       "stopAtEntry": false,

--- a/src/Cdc.Vocabulary.WebApi.csproj
+++ b/src/Cdc.Vocabulary.WebApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Erik Knudsen</Authors>
@@ -11,7 +11,7 @@
     <PackageLicenseUrl>https://opensource.org/licenses/Apache-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/erik1066/vocabulary-api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <IsTestProject>false</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -27,11 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0-rc3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
     <PackageReference Include="AutoMapper" Version="8.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Cdc.Vocabulary.WebApi.csproj
+++ b/src/Cdc.Vocabulary.WebApi.csproj
@@ -33,6 +33,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
     <PackageReference Include="AutoMapper" Version="8.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Spark.Engine.R4" Version="1.3.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="1.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Cdc.Vocabulary.WebApi.csproj
+++ b/src/Cdc.Vocabulary.WebApi.csproj
@@ -27,10 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0-preview8.19405.11" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0-preview8.19405.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0-rc2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0-rc3" />
     <PackageReference Include="AutoMapper" Version="8.1.1" />
   </ItemGroup>
 

--- a/src/Controllers/FhirController.cs
+++ b/src/Controllers/FhirController.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Spark.Engine.Extensions;
+using Cdc.Vocabulary.WebApi.Models;
+using Cdc.Vocabulary.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Cdc.Vocabulary.WebApi.Controllers
+{
+    /// <summary>
+    /// Index route controller class
+    /// </summary>
+    [ApiController]
+    [Route("api/fhir")]
+    [AllowAnonymous]
+    public sealed class FhirController : ControllerBase
+    {
+        #region Private Members
+        private readonly ILogger<FhirController> _logger;
+        private readonly IValueSetRepository _valueSetRepository;
+        private readonly IValueSetVersionRepository _valueSetVersionRepository;
+        private readonly IValueSetConceptRepository _valueSetConceptRepository;
+        private readonly ICodeSystemRepository _codeSystemRepository;
+
+        private static FhirJsonSerializer _fhirJsonSerializer = new FhirJsonSerializer(new SerializerSettings()
+        {
+            Pretty = true
+        });
+
+        private static CapabilityStatement _capabilityStatement = new CapabilityStatement()
+        {
+            FhirVersion = FHIRVersion.N4_0_1,
+            Status = PublicationStatus.Active,
+            Date = new DateTime(2020, 01, 01).ToString(), // TODO: Convert to proper FHIR date time string
+            Format = new List<string>() { "json "},
+            Rest = new List<CapabilityStatement.RestComponent>() { 
+                new CapabilityStatement.RestComponent() 
+                {
+                    Mode = CapabilityStatement.RestfulCapabilityMode.Server,
+                    Resource = new List<CapabilityStatement.ResourceComponent>()
+                    {
+                        new CapabilityStatement.ResourceComponent()
+                        {
+                            Type = ResourceType.ValueSet,
+                            Interaction = new List<CapabilityStatement.ResourceInteractionComponent>() 
+                            {
+                                new CapabilityStatement.ResourceInteractionComponent()
+                                {
+                                    Code = CapabilityStatement.TypeRestfulInteraction.Read
+                                },
+                                new CapabilityStatement.ResourceInteractionComponent()
+                                {
+                                    Code = CapabilityStatement.TypeRestfulInteraction.Vread
+                                },
+                                new CapabilityStatement.ResourceInteractionComponent()
+                                {
+                                    Code = CapabilityStatement.TypeRestfulInteraction.SearchType
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        #endregion // Private Members
+
+        public FhirController(
+            ILogger<FhirController> logger,
+            IValueSetRepository valueSetRepository,
+            IValueSetVersionRepository valueSetVersionRepository,
+            IValueSetConceptRepository valueSetConceptRepository,
+            ICodeSystemRepository codeSystemRepository)
+        {
+            _logger = logger;
+            _valueSetRepository = valueSetRepository;
+            _valueSetVersionRepository = valueSetVersionRepository;
+            _valueSetConceptRepository = valueSetConceptRepository;
+            _codeSystemRepository = codeSystemRepository;
+        }
+        
+        // GET api/fhir/metadata
+        /// <summary>
+        /// Gets the capabilities statement of this server
+        /// </summary>
+        /// <returns>Capabilities statement</returns>
+        [HttpGet("metadata")]
+        [Produces("application/json")]
+        public IActionResult Metadata()
+        {
+            string fhirContent = _fhirJsonSerializer.SerializeToString(_capabilityStatement);
+            return Content(fhirContent);
+        }
+
+        // GET api/fhir/[type]/[id] {?_format=[mime-type]}
+        /// <summary>
+        /// Gets a resource by its ID
+        /// </summary>
+        /// <remarks>
+        /// See https://www.hl7.org/fhir/http.html#read
+        /// </remarks>
+        /// <returns>FHIR Resource</returns>
+        [HttpGet("{type}/{id}")]
+        [Produces("application/json")]
+        public IActionResult GetResourceById(string type, string id)
+        {
+            throw new NotImplementedException();
+        }
+
+        // GET api/fhir/[type]/[id] {?_format=[mime-type]}
+        /// <summary>
+        /// Gets a resource by its ID
+        /// </summary>
+        /// <remarks>
+        /// See https://www.hl7.org/fhir/http.html#vread
+        /// </remarks>
+        /// <returns>FHIR Resource</returns>
+        [HttpGet("{type}/{id}/_history/{vid}")]
+        [Produces("application/json")]
+        [ResponseCache(VaryByHeader = "User-Agent", Location = ResponseCacheLocation.Any, Duration = 86_400, NoStore = false)]
+        public IActionResult GetVersionedResourceById(string type, string id, string vid)
+        {
+            if (!type.Equals("ValueSet", StringComparison.OrdinalIgnoreCase))
+            {
+                return NotFound();
+            }
+
+            Guid versionGuid = new Guid(vid);
+            Guid valueSetGuid = new Guid(id);
+
+            var valueSetVersionFromRepo = _valueSetVersionRepository.GetValueSetVersion(versionGuid);
+            var valueSetFromRepo = _valueSetRepository.GetValueSet(valueSetGuid);
+
+            if (valueSetFromRepo.ValueSetOID != valueSetVersionFromRepo.ValueSetOID)
+            {
+                return NotFound();
+            }
+
+            var valueSet = BuildValueSet(valueSetVersionFromRepo, valueSetFromRepo);
+
+            string fhirContent = _fhirJsonSerializer.SerializeToString(valueSet);
+            return Content(fhirContent);
+        }
+
+        // GET api/fhir/[type]{?[parameters]{&_format=[mime-type]}}
+        /// <summary>
+        /// Searches FHIR resources
+        /// </summary>
+        /// <remarks>
+        /// See https://www.hl7.org/fhir/http.html#search
+        /// </remarks>
+        /// <returns>FHIR Resources</returns>
+        [HttpGet("{type}")]
+        [Produces("application/json")]
+        public IActionResult SearchResources(string type)
+        {
+            var searchparams = Request.GetSearchParams();
+            throw new NotImplementedException();
+        }
+
+        #region Private methods
+        private ValueSet BuildValueSet(Entities.ValueSetVersion valueSetVersionFromRepo, Entities.ValueSet valueSetFromRepo)
+        {
+            var valueSet = new Hl7.Fhir.Model.ValueSet();
+            valueSet.Identifier = new List<Identifier>()
+            {
+                new Identifier()
+                {
+                    Use = Identifier.IdentifierUse.Official,
+                    Value = valueSetVersionFromRepo.ValueSetVersionID.ToString(),
+                    System = "urn:ietf:rfc:3986"
+                },
+                new Identifier()
+                {
+                    Use = Identifier.IdentifierUse.Secondary,
+                    Value = valueSetVersionFromRepo.ValueSetOID
+                },
+                new Identifier()
+                {
+                    Use = Identifier.IdentifierUse.Secondary,
+                    Value = valueSetVersionFromRepo.ValueSetCode
+                }
+            };
+            valueSet.Name = valueSetFromRepo.ValueSetName;
+            valueSet.Publisher = "PHIN_VADS";
+            valueSet.DateElement = new FhirDateTime(valueSetVersionFromRepo.StatusDate);
+            valueSet.Version = valueSetVersionFromRepo.ValueSetVersionNumber.ToString();
+            valueSet.VersionId = valueSetVersionFromRepo.ValueSetVersionID.ToString();
+            valueSet.Expansion = new ValueSet.ExpansionComponent()
+            {
+                Identifier = Guid.NewGuid().ToString(),
+                TimestampElement = new FhirDateTime(DateTimeOffset.Now),
+                Contains = new List<ValueSet.ContainsComponent>()
+            };
+            valueSet.Status = PublicationStatus.Active;
+
+            var paginationParameters = new ValueSetConceptPaginationParameters()
+            {
+                ValueSetVersionId = valueSetVersionFromRepo.ValueSetVersionID,
+                ValueSetVersionNumber = valueSetVersionFromRepo.ValueSetVersionNumber.ToString(),
+                PageSize = 1000
+            };
+            var valueSetConceptEntities = _valueSetConceptRepository.GetValueSetConcepts(paginationParameters);
+
+            foreach (var conceptFromRepo in valueSetConceptEntities)
+            {
+                var component = new ValueSet.ContainsComponent()
+                {
+                    Code = conceptFromRepo.ConceptCode,
+                    Display = conceptFromRepo.CDCPreferredDesignation,
+                    System = $"urn:oid:{conceptFromRepo.CodeSystemOID}",
+                    Extension = new List<Extension>()
+                    {
+                        new Extension()
+                        {
+                            Value = new FhirString(conceptFromRepo.HL70396Identifier)
+                        }
+                    }
+                };
+                valueSet.Expansion.Contains.Add(component);
+            }
+
+            valueSet.Expansion.Total = valueSet.Expansion.Contains.Count;
+            valueSet.Expansion.Offset = paginationParameters.PageNumber - 1;
+
+            return valueSet;
+        }
+        #endregion // Private methods
+    }
+}

--- a/src/Models/ValueSetConceptForRetrievalDto.cs
+++ b/src/Models/ValueSetConceptForRetrievalDto.cs
@@ -10,19 +10,44 @@ namespace Cdc.Vocabulary.WebApi.Models
         public Guid Id { get; set; } = default(Guid);
 
         /// <summary>
-        /// The OID that identifies the CodeSystem with which this ValueSetConcept is associated.
-        /// </summary>
-        public string CodeSystemOid { get; set; } = string.Empty;
-
-        /// <summary>
         /// The GUID that identifies the ValueSetVersion with which this ValueSetConcept is associated.
         /// </summary>
         public string ValueSetVersionId { get; set; } = string.Empty;
 
         /// <summary>
+        /// The version number of the value set to which this concept belongs
+        /// </summary>
+        public int? ValueSetVersionNumber { get; set; }
+
+        /// <summary>
+        /// The code of the value set to which this concept belongs
+        /// </summary>
+        public string ValueSetCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The OID of the value set to which this concept belongs
+        /// </summary>
+        public string ValueSetOid { get; set; } = string.Empty;
+
+        /// <summary>
         /// The conceptCode text that uniquely identifies this ValueSetConcept within a ValueSetVersion or a CodeSystem.
         /// </summary>
         public string Code { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The "preferred term", the designation the CDC believes is most desired for use when representing the concept.
+        /// </summary>
+        public string CdcPreferredDesignation { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Name of the CodeSystemConcept which was used as the source for this ValueSetConcept.
+        /// </summary>
+        public string CodeSystemConceptName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// TODO: Fill this in
+        /// </summary>
+        public string Hl70396Identifier { get; set; } = string.Empty;
 
         /// <summary>
         /// The text that describes the scope of this ValueSetConcept
@@ -40,11 +65,6 @@ namespace Cdc.Vocabulary.WebApi.Models
         public DateTimeOffset StatusDate { get; set; }
 
         /// <summary>
-        /// The "preferred term", the designation the CDC believes is most desired for use when representing the concept.
-        /// </summary>
-        public string CdcPreferredDesignation { get; set; } = string.Empty;
-
-        /// <summary>
         /// Actual description or synonym name or text provided by SDO for this Concept where the Alternate Designation is defined as a Code and is the PHIN Preferred Term for this Concept.
         /// </summary>
         public string PreferredAlternateCode { get; set; } = string.Empty;
@@ -55,23 +75,13 @@ namespace Cdc.Vocabulary.WebApi.Models
         public string Definition { get; set; } = string.Empty;
 
         /// <summary>
-        /// The Name of the CodeSystemConcept which was used as the source for this ValueSetConcept.
+        /// The OID that identifies the CodeSystem with which this ValueSetConcept is associated.
         /// </summary>
-        public string CodeSystemConceptName { get; set; } = string.Empty;
+        public string CodeSystemOid { get; set; } = string.Empty;
 
         /// <summary>
-        /// TODO: Fill this in
-        /// </summary>
-        public string Hl70396Identifier { get; set; } = string.Empty;
-
-        /// <summary>
-        /// TODO: Fill this in
+        /// A number that indicates the preferred positioning of this concept when the concept is displayed on a client system
         /// </summary>
         public int? Sequence { get; set; }
-
-        /// <summary>
-        /// TODO: Fill this in
-        /// </summary>
-        public int? ValueSetVersionNumber { get; set; }
     }
 }

--- a/src/Services/ICodeSystemRepository.cs
+++ b/src/Services/ICodeSystemRepository.cs
@@ -14,11 +14,11 @@ namespace Cdc.Vocabulary.Services
 
         CodeSystem GetCodeSystem(Guid id);
 
-        void AddCodeSystem(CodeSystem codeSystem);
+        // void AddCodeSystem(CodeSystem codeSystem);
 
-        void DeleteCodeSystem(CodeSystem codeSystem);
+        // void DeleteCodeSystem(CodeSystem codeSystem);
 
-        void UpdateCodeSystem(CodeSystem codeSystem);
+        // void UpdateCodeSystem(CodeSystem codeSystem);
 
         bool CodeSystemExists(Guid id);
 

--- a/src/Services/IValueSetConceptRepository.cs
+++ b/src/Services/IValueSetConceptRepository.cs
@@ -14,11 +14,11 @@ namespace Cdc.Vocabulary.Services
 
         ValueSetConcept GetValueSetConcept(Guid id);
 
-        void AddValueSetConcept(ValueSetConcept valueSetConcept);
+        // void AddValueSetConcept(ValueSetConcept valueSetConcept);
 
-        void DeleteValueSetConcept(ValueSetConcept valueSetConcept);
+        // void DeleteValueSetConcept(ValueSetConcept valueSetConcept);
 
-        void UpdateValueSetConcept(ValueSetConcept valueSetConcept);
+        // void UpdateValueSetConcept(ValueSetConcept valueSetConcept);
 
         bool ValueSetConceptExists(Guid id);
 

--- a/src/Services/IValueSetRepository.cs
+++ b/src/Services/IValueSetRepository.cs
@@ -16,11 +16,11 @@ namespace Cdc.Vocabulary.Services
 
         ValueSet GetValueSet(string id);
 
-        void AddValueSet(ValueSet valueSet);
+        // void AddValueSet(ValueSet valueSet);
 
-        void DeleteValueSet(ValueSet valueSet);
+        // void DeleteValueSet(ValueSet valueSet);
 
-        void UpdateValueSet(ValueSet valueSet);
+        // void UpdateValueSet(ValueSet valueSet);
 
         bool ValueSetExists(Guid id);
 

--- a/src/Services/IValueSetVersionRepository.cs
+++ b/src/Services/IValueSetVersionRepository.cs
@@ -14,11 +14,11 @@ namespace Cdc.Vocabulary.Services
 
         ValueSetVersion GetValueSetVersion(Guid id);
 
-        void AddValueSetVersion(ValueSetVersion valueSetVersion);
+        // void AddValueSetVersion(ValueSetVersion valueSetVersion);
 
-        void DeleteValueSetVersion(ValueSetVersion valueSetVersion);
+        // void DeleteValueSetVersion(ValueSetVersion valueSetVersion);
 
-        void UpdateValueSetVersion(ValueSetVersion valueSetVersion);
+        // void UpdateValueSetVersion(ValueSetVersion valueSetVersion);
 
         bool ValueSetVersionExists(Guid id);
 

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -90,6 +90,14 @@ namespace Cdc.Vocabulary.WebApi
                 app.UseDeveloperExceptionPage();
             }
 
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("X-Frame-Options", "DENY"); // Prevents being loaded in a frame
+                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");  // Prevents Internet Explorer from MIME-sniffing a response away from the declared content-type.
+                context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
+                await next();
+            });
+
             app.UseHttpsRedirection();
 
             app.UseDefaultFiles(); // will ensure index.html is returned when no resource is specified; this must come before the UseStaticFiles() line below

--- a/tests/unit/.vscode/launch.json
+++ b/tests/unit/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.0/Cdc.Vocabulary.Tests.dll",
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/Cdc.Vocabulary.Tests.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/tests/unit/Cdc.Vocabulary.Tests.csproj
+++ b/tests/unit/Cdc.Vocabulary.Tests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0-preview8.19405.11" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/unit/Cdc.Vocabulary.Tests.csproj
+++ b/tests/unit/Cdc.Vocabulary.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -15,7 +15,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
     <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/unit/Dockerfile.test
+++ b/tests/unit/Dockerfile.test
@@ -1,5 +1,5 @@
 # Test stage
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 as test
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as test
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT true
 


### PR DESCRIPTION
This PR includes a basic FHIR API consisting of a GET capabilities statement and a GET for ValueSet versions. It also bumps the .NET Core version from 3.0 to 3.1, which is the latest LTS release. Some other minor code cleanup work is included.